### PR TITLE
List名をnamesからMleagerListに変更・suzuki.Y,setokumaをListに追加

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -4,20 +4,19 @@ import java.util.List;
 
 public class Main {
     public static void main(String[] args) {
-        List<String> names = List.of("nakabayashi","suzuki", "honda","mizuhara","kobayashi");
+        List<String> MleagerList = List.of("nakabayashi","suzuki.T", "honda","mizuhara","kobayashi","suzuki.Y","setokuma");
 
-        names.stream().map(String::toUpperCase).forEach(System.out::println);
-        names.stream().map(String::toLowerCase).forEach(System.out::println);
+        MleagerList.stream().map(String::toUpperCase).forEach(System.out::println);
+        MleagerList.stream().map(String::toLowerCase).forEach(System.out::println);
 
-        List<String> SortedResult = names.stream().sorted().toList();
+        List<String> SortedResult = MleagerList.stream().sorted().toList();
         SortedResult.forEach(System.out::println);
 
-        long count = names.stream().filter(List.of("honda","mizuhara")::contains).count();
+        long count = MleagerList.stream().filter(List.of("honda","mizuhara")::contains).count();
         System.out.println(count);
 
-        boolean hasbayashi = names.stream().anyMatch(List.of("kobayashi")::contains);
+        boolean hasbayashi = MleagerList.stream().anyMatch(List.of("kobayashi")::contains);
         System.out.println(hasbayashi);
-
 
 
     }

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public class Main {
     public static void main(String[] args) {
-        List<String> MleagerList = List.of("nakabayashi","suzuki.T", "honda","mizuhara","kobayashi","suzuki.Y","setokuma");
+        List<String> MleagerList = List.of("nakabayashi","suzuki.Y", "honda","mizuhara","kobayashi","suzuki.T","setokuma");
 
         MleagerList.stream().map(String::toUpperCase).forEach(System.out::println);
         MleagerList.stream().map(String::toLowerCase).forEach(System.out::println);


### PR DESCRIPTION
# 概要
・List名をnamesからMleagerListに変更
・MleagerListにsuzuki.Y,setokumaを追加
・苗字に重複がある場合、名前のイニシャルを追加

# 動作確認
<img width="178" alt="スクリーンショット 2023-11-30 15 58 15" src="https://github.com/Senzuwa/MethodLesson/assets/151819109/3749373c-aab6-4f1c-85d7-4cb953a78230">
